### PR TITLE
change Makefile variable to something more meaningul

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-ifneq ($(INTEL_AUDIO_HAL),imc)
+ifeq ($(INTEL_AUDIO_HAL),audio_pfw)
 
 LOCAL_PATH := $(call my-dir)
 include $(OPTIONAL_QUALITY_ENV_SETUP)


### PR DESCRIPTION
INTEL_AUDIO_HAL:= audio -> baseline HAL
INTEL_AUDIO_HAL:= audio_pfw -> PFW-based HAL

The two HALs can be part of the same tree but not included in the
same build

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>