### PR TITLE
Renaming of audio_comms namescpace to audio_utilities

### DIFF
--- a/audio_conversion/Android.mk
+++ b/audio_conversion/Android.mk
@@ -1,6 +1,6 @@
 #
 #
-# Copyright (C) Intel 2013-2016
+# Copyright (C) Intel 2013-2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ component_includes_dir_target := \
 
 component_static_lib := \
     libsamplespec_static \
-    libaudio_comms_utilities
+    libaudio_utilities
 
 component_static_lib_host += \
     $(foreach lib, $(component_static_lib), $(lib)_host)
@@ -116,7 +116,7 @@ component_fcttest_c_includes := \
 # Other Lib
 component_fcttest_static_lib := \
     libsamplespec_static \
-    libaudio_comms_utilities \
+    libaudio_utilities \
     libaudioconversion_static
 
 # Compile macro

--- a/audio_conversion/include/AudioConversion.hpp
+++ b/audio_conversion/include/AudioConversion.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ namespace intel_audio
 
 class AudioConverter;
 
-class AudioConversion : public audio_comms::utilities::NonCopyable
+class AudioConversion : public audio_utilities::utilities::NonCopyable
 {
 public:
     typedef std::list<AudioConverter *>::iterator AudioConverterListIterator;

--- a/audio_conversion/src/AudioConversion.cpp
+++ b/audio_conversion/src/AudioConversion.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 #include <media/AudioBufferProvider.h>
 #include <stdlib.h>
 
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 using namespace android;
 using namespace std;
 

--- a/audio_conversion/src/AudioConverter.cpp
+++ b/audio_conversion/src/AudioConverter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 #include <utilities/Log.hpp>
 #include <stdlib.h>
 
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 using namespace android;
 
 namespace intel_audio

--- a/audio_conversion/src/AudioConverter.hpp
+++ b/audio_conversion/src/AudioConverter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 #include <AudioNonCopyable.hpp>
 #include <utils/Errors.h>
 
-using audio_comms::utilities::NonCopyable;
+using audio_utilities::utilities::NonCopyable;
 
 namespace intel_audio
 {

--- a/audio_conversion/src/AudioReformatter.cpp
+++ b/audio_conversion/src/AudioReformatter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 #include <utility>
 #include <vector>
 
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 using namespace android;
 
 namespace intel_audio

--- a/audio_conversion/src/AudioRemapper.cpp
+++ b/audio_conversion/src/AudioRemapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 #include <utilities/Log.hpp>
 
 using namespace android;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 
 namespace intel_audio
 {

--- a/audio_conversion/src/AudioResampler.cpp
+++ b/audio_conversion/src/AudioResampler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 #include <audio_utils/resampler.h>
 #include <limits.h>
 
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 using namespace android;
 
 namespace intel_audio

--- a/audio_conversion/test/AudioConversionTest.hpp
+++ b/audio_conversion/test/AudioConversionTest.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016 Intel Corporation
+ * Copyright (C) 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ namespace intel_audio
 
 class MyAudioBufferProvider
     : public android::AudioBufferProvider,
-      private audio_comms::utilities::NonCopyable
+      private audio_utilities::utilities::NonCopyable
 {
 
 public:

--- a/audio_dump_lib/Android.mk
+++ b/audio_dump_lib/Android.mk
@@ -1,6 +1,6 @@
 #
 #
-# Copyright (C) Intel 2013-2016
+# Copyright (C) Intel 2013-2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ component_includes_dir_target := \
     $(component_export_includes_dir) \
     $(call include-path-for, bionic)
 
-component_static_lib := libaudio_comms_utilities
+component_static_lib := libaudio_utilities
 
 component_static_lib_host := \
     $(foreach lib, $(component_static_lib), $(lib)_host)

--- a/audio_dump_lib/HalAudioDump.cpp
+++ b/audio_dump_lib/HalAudioDump.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
 
 using namespace android;
 using namespace std;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 
 const char *HalAudioDump::mStreamDirections[] = {
     "in", "out"

--- a/audio_platform_state/Android.mk
+++ b/audio_platform_state/Android.mk
@@ -1,6 +1,6 @@
 #
 #
-# Copyright (C) Intel 2013-2016
+# Copyright (C) Intel 2013-2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -55,8 +55,8 @@ component_static_lib := \
     libsamplespec_static \
     libstream_static \
     libparametermgr_static \
-    libaudio_comms_utilities \
-    libaudio_comms_convert \
+    libaudio_utilities \
+    libaudio_utilities_convert \
     libaudio_hal_utilities \
     liblpepreprocessinghelper \
     libaudioutilities_naive_tokenizer \

--- a/audio_platform_state/include/AudioPlatformState.hpp
+++ b/audio_platform_state/include/AudioPlatformState.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ namespace intel_audio
 
 class ParameterMgrPlatformConnectorLogger;
 
-class AudioPlatformState : private audio_comms::utilities::NonCopyable
+class AudioPlatformState : private audio_utilities::utilities::NonCopyable
 {
 private:
     /**

--- a/audio_platform_state/include/Parameter.hpp
+++ b/audio_platform_state/include/Parameter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016 Intel Corporation
+ * Copyright (C) 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ namespace intel_audio
  * or path (for a rogue parameter). This object will allow to wrap setter and getter on this
  * android-parameter to the associated element in the Parameter Manager.
  */
-class Parameter : private audio_comms::utilities::NonCopyable
+class Parameter : private audio_utilities::utilities::NonCopyable
 {
 public:
     enum Type

--- a/audio_platform_state/src/AudioPlatformState.cpp
+++ b/audio_platform_state/src/AudioPlatformState.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,10 +36,10 @@
 #include <fstream>
 
 using namespace std;
-using audio_comms::utilities::convertTo;
+using audio_utilities::utilities::convertTo;
 using android::status_t;
-using audio_comms::utilities::Log;
-using audio_comms::utilities::Property;
+using audio_utilities::utilities::Log;
+using audio_utilities::utilities::Property;
 
 namespace intel_audio
 {

--- a/audio_platform_state/src/CriterionParameter.cpp
+++ b/audio_platform_state/src/CriterionParameter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 Intel Corporation
+ * Copyright (C) 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 #include <convert.hpp>
 #include <utilities/Log.hpp>
 
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 
 namespace intel_audio
 {

--- a/audio_platform_state/src/Parameter.cpp
+++ b/audio_platform_state/src/Parameter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 Intel Corporation
+ * Copyright (C) 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 #include <utilities/Log.hpp>
 
 using std::string;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 
 namespace intel_audio
 {

--- a/audio_platform_state/src/Pfw.cpp
+++ b/audio_platform_state/src/Pfw.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,9 +38,9 @@
 #endif
 
 using namespace std;
-using audio_comms::utilities::Log;
-using audio_comms::utilities::Property;
-using audio_comms::utilities::convertTo;
+using audio_utilities::utilities::Log;
+using audio_utilities::utilities::Property;
+using audio_utilities::utilities::convertTo;
 
 namespace intel_audio
 {

--- a/audio_platform_state/src/Pfw.hpp
+++ b/audio_platform_state/src/Pfw.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ class ParameterMgrPlatformConnectorLogger;
 typedef std::pair<std::string, std::string> AndroidParamMappingValuePair;
 
 template <class Trait>
-class Pfw : private audio_comms::utilities::NonCopyable
+class Pfw : private audio_utilities::utilities::NonCopyable
 {
 private:
     typedef std::map<std::string, CriterionType *> CriterionTypes;

--- a/audio_platform_state/src/RogueParameter.hpp
+++ b/audio_platform_state/src/RogueParameter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 Intel Corporation
+ * Copyright (C) 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,17 +62,17 @@ protected:
     {
         std::string literalParamValue = getDefaultLiteralValue();
         if (!getLiteralValueFromParam(androidParamValue, literalParamValue)) {
-            audio_comms::utilities::Log::Warning() << __FUNCTION__
+            audio_utilities::utilities::Log::Warning() << __FUNCTION__
                                                    << ": unknown parameter value "
                                                    << androidParamValue
                                                    << " for " << getKey();
             return false;
         }
-        audio_comms::utilities::Log::Verbose() << __FUNCTION__
+        audio_utilities::utilities::Log::Verbose() << __FUNCTION__
                                                << ": " << getName() << " (" << androidParamValue
                                                << ", " << literalParamValue << ")";
 
-        return audio_comms::utilities::convertTo(literalParamValue, rogueValue);
+        return audio_utilities::utilities::convertTo(literalParamValue, rogueValue);
     }
 
     /**
@@ -88,7 +88,7 @@ protected:
     bool convertValueToAndroidParamValue(const T &rogueValue, std::string &androidParamValue) const
     {
         std::string literalValue = "";
-        return audio_comms::utilities::convertTo(rogueValue, literalValue) &&
+        return audio_utilities::utilities::convertTo(rogueValue, literalValue) &&
                getParamFromLiteralValue(androidParamValue, literalValue);
     }
 
@@ -111,7 +111,7 @@ protected:
     virtual bool sync()
     {
         T typedValue;
-        return audio_comms::utilities::convertTo(getDefaultLiteralValue(), typedValue) &&
+        return audio_utilities::utilities::convertTo(getDefaultLiteralValue(), typedValue) &&
                ParameterMgrHelper::setParameterValue<T>(mParameterMgrConnector, getName(),
                                                         typedValue);
     }

--- a/audio_platform_state/src/VolumeKeys.cpp
+++ b/audio_platform_state/src/VolumeKeys.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 #include <utilities/Log.hpp>
 #include <fcntl.h>
 
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 
 namespace intel_audio
 {

--- a/audio_route_manager/Android.mk
+++ b/audio_route_manager/Android.mk
@@ -1,6 +1,6 @@
 #
 #
-# Copyright (C) Intel 2013-2016
+# Copyright (C) Intel 2013-2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -66,8 +66,8 @@ component_static_lib := \
     libaudioplatformstate \
     libparametermgr_static \
     libaudioparameters \
-    libaudio_comms_utilities \
-    libaudio_comms_convert \
+    libaudio_utilities \
+    libaudio_utilities_convert \
     libproperty \
     liblpepreprocessinghelper \
     libevent-listener_static \

--- a/audio_route_manager/AudioPort.cpp
+++ b/audio_route_manager/AudioPort.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 #include <utilities/Log.hpp>
 
 using std::string;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 
 namespace intel_audio
 {

--- a/audio_route_manager/AudioPortGroup.cpp
+++ b/audio_route_manager/AudioPortGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 #include <utilities/Log.hpp>
 
 using std::string;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 
 namespace intel_audio
 {

--- a/audio_route_manager/AudioRoute.cpp
+++ b/audio_route_manager/AudioRoute.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 #include <utilities/Log.hpp>
 
 using std::string;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 
 namespace intel_audio
 {

--- a/audio_route_manager/AudioRoute.hpp
+++ b/audio_route_manager/AudioRoute.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ namespace intel_audio
 
 class AudioPort;
 
-class AudioRoute : public audio_comms::utilities::NonCopyable
+class AudioRoute : public audio_utilities::utilities::NonCopyable
 {
 
 public:

--- a/audio_route_manager/AudioRouteManager.cpp
+++ b/audio_route_manager/AudioRouteManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,9 +43,9 @@ static const char *const uevent_socket_name = "uevent_emulation";
 
 using android::status_t;
 using namespace std;
-using audio_comms::utilities::BitField;
-using audio_comms::utilities::Log;
-using audio_comms::utilities::Property;
+using audio_utilities::utilities::BitField;
+using audio_utilities::utilities::Log;
+using audio_utilities::utilities::Property;
 typedef android::RWLock::AutoRLock AutoR;
 typedef android::RWLock::AutoWLock AutoW;
 

--- a/audio_route_manager/AudioRouteManager.hpp
+++ b/audio_route_manager/AudioRouteManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,8 +51,8 @@ struct pcm_config;
 class AudioRouteManager : public IStreamInterface,
                           public IRouteInterface,
                           private IEventListener,
-                          private audio_comms::utilities::Observable,
-                          private audio_comms::utilities::NonCopyable
+                          private audio_utilities::utilities::Observable,
+                          private audio_utilities::utilities::NonCopyable
 {
 public:
     AudioRouteManager();

--- a/audio_route_manager/AudioRouteManagerObserver.hpp
+++ b/audio_route_manager/AudioRouteManagerObserver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ namespace intel_audio
 
 class AudioPort;
 
-class AudioRouteManagerObserver : public audio_comms::utilities::Observer
+class AudioRouteManagerObserver : public audio_utilities::utilities::Observer
 {
 public:
     AudioRouteManagerObserver();

--- a/audio_route_manager/AudioStreamRoute.cpp
+++ b/audio_route_manager/AudioStreamRoute.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
 #include <policy.h>
 
 using std::string;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 
 namespace intel_audio
 {

--- a/audio_route_manager/ElementCollection.hpp
+++ b/audio_route_manager/ElementCollection.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Intel Corporation
+ * Copyright (C) 2015-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public:
     bool addElement(const std::string &key, T *element)
     {
         if (getElement(key) != NULL) {
-            audio_comms::utilities::Log::Warning() << __FUNCTION__
+            audio_utilities::utilities::Log::Warning() << __FUNCTION__
                                                    << ": element(" << key << ") already added";
             return false;
         }

--- a/audio_route_manager/RouteCollection.hpp
+++ b/audio_route_manager/RouteCollection.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Intel Corporation
+ * Copyright (C) 2015-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public:
     {
         AudioRoute *route = Base::getElement(name);
         if (!route) {
-            audio_comms::utilities::Log::Error() << __FUNCTION__ << ": invalid route " << name;
+            audio_utilities::utilities::Log::Error() << __FUNCTION__ << ": invalid route " << name;
             return;
         }
         route->setApplicable(isApplicable);
@@ -75,7 +75,7 @@ public:
     {
         AudioRoute *route = Base::getElement(name);
         if (!route) {
-            audio_comms::utilities::Log::Error() << __FUNCTION__ << ": invalid route " << name;
+            audio_utilities::utilities::Log::Error() << __FUNCTION__ << ": invalid route " << name;
             return;
         }
         route->setNeedReconfigure(needReconfigure);
@@ -85,7 +85,7 @@ public:
     {
         AudioRoute *route = Base::getElement(name);
         if (!route) {
-            audio_comms::utilities::Log::Error() << __FUNCTION__ << ": invalid route " << name;
+            audio_utilities::utilities::Log::Error() << __FUNCTION__ << ": invalid route " << name;
             return;
         }
         route->setNeedReroute(needReroute);

--- a/audio_route_manager/RoutingElement.hpp
+++ b/audio_route_manager/RoutingElement.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 namespace intel_audio
 {
 
-class RoutingElement : public audio_comms::utilities::NonCopyable
+class RoutingElement : public audio_utilities::utilities::NonCopyable
 {
 public:
     RoutingElement(const std::string &name);

--- a/audio_route_manager/StreamRouteCollection.hpp
+++ b/audio_route_manager/StreamRouteCollection.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Intel Corporation
+ * Copyright (C) 2015-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ public:
         // We take the first stream that corresponds to the primary output.
         auto it = mOrderedStreamList[Direction::Output].begin();
         if (*it == NULL) {
-            audio_comms::utilities::Log::Error() << __FUNCTION__
+            audio_utilities::utilities::Log::Error() << __FUNCTION__
                                                  << ": current stream NOT FOUND for echo ref";
         }
         return *it;
@@ -87,7 +87,7 @@ public:
     {
         AudioStreamRoute *route = getElement(name);
         if (!route) {
-            audio_comms::utilities::Log::Error() << __FUNCTION__ << ": invalid route " << name;
+            audio_utilities::utilities::Log::Error() << __FUNCTION__ << ": invalid route " << name;
             return;
         }
         route->updateStreamRouteConfig(config);
@@ -97,7 +97,7 @@ public:
     {
         AudioStreamRoute *route = getElement(name);
         if (!route) {
-            audio_comms::utilities::Log::Error() << __FUNCTION__ << ": invalid route " << name;
+            audio_utilities::utilities::Log::Error() << __FUNCTION__ << ": invalid route " << name;
             return;
         }
         route->addEffectSupported(effect);
@@ -130,7 +130,7 @@ public:
             auto route = it.second;
 
             if (route && ((route->previouslyUsed() && !route->isUsed()) || route->needRepath())) {
-                audio_comms::utilities::Log::Verbose() << __FUNCTION__
+                audio_utilities::utilities::Log::Verbose() << __FUNCTION__
                                                        << ": Route " << route->getName()
                                                        << " to be disabled";
                 route->unroute(isPostDisable);
@@ -154,11 +154,11 @@ public:
             auto route = it.second;
 
             if (route && ((!route->previouslyUsed() && route->isUsed()) || route->needRepath())) {
-                audio_comms::utilities::Log::Verbose() << __FUNCTION__
+                audio_utilities::utilities::Log::Verbose() << __FUNCTION__
                                                        << ": Route" << route->getName()
                                                        << " to be enabled";
                 if (route->route(isPreEnable) != android::OK) {
-                    audio_comms::utilities::Log::Error() << "\t error while routing "
+                    audio_utilities::utilities::Log::Error() << "\t error while routing "
                                                          << route->getName();
                 }
             }

--- a/audio_route_manager/includes/AudioCapabilities.hpp
+++ b/audio_route_manager/includes/AudioCapabilities.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Intel Corporation
+ * Copyright (C) 2015-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -173,7 +173,7 @@ struct AudioCapabilities
         std::string formattedRates;
         for (auto &rate : supportedRates) {
             std::string literalRate;
-            if (audio_comms::utilities::convertTo(rate, literalRate)) {
+            if (audio_utilities::utilities::convertTo(rate, literalRate)) {
                 formattedRates += literalRate;
             }
             if (&rate != &supportedRates.back()) {

--- a/audio_route_manager/includes/RouteManagerInstance.hpp
+++ b/audio_route_manager/includes/RouteManagerInstance.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ namespace intel_audio
 
 class AudioRouteManager;
 
-class RouteManagerInstance : public audio_comms::utilities::NonCopyable
+class RouteManagerInstance : public audio_utilities::utilities::NonCopyable
 {
 protected:
     RouteManagerInstance();

--- a/audio_route_manager/parameter_framework_plugin/Android.mk
+++ b/audio_route_manager/parameter_framework_plugin/Android.mk
@@ -35,8 +35,8 @@ component_common_includes_dir := \
     external/tinyalsa/include
 
 component_static_lib := \
-    libaudio_comms_utilities \
-    libaudio_comms_convert \
+    libaudio_utilities \
+    libaudio_utilities_convert \
     libsamplespec_static \
     libpfw_utility
 

--- a/audio_route_manager/parameter_framework_plugin/RouteSubsystem.hpp
+++ b/audio_route_manager/parameter_framework_plugin/RouteSubsystem.hpp
@@ -24,7 +24,7 @@ namespace intel_audio
 struct IRouteInterface;
 }
 
-class RouteSubsystem : public CSubsystem, private audio_comms::utilities::NonCopyable
+class RouteSubsystem : public CSubsystem, private audio_utilities::utilities::NonCopyable
 {
 public:
     RouteSubsystem(const std::string &strName, core::log::Logger &logger);

--- a/audio_route_manager/test/HdmiAudioStreamRoute.cpp
+++ b/audio_route_manager/test/HdmiAudioStreamRoute.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Intel Corporation
+ * Copyright (C) 2015-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 
 using android::status_t;
 using std::string;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 
 namespace intel_audio
 {

--- a/audio_stream_manager/Android.mk
+++ b/audio_stream_manager/Android.mk
@@ -1,6 +1,6 @@
 #
 #
-# Copyright (C) Intel 2013-2016
+# Copyright (C) Intel 2013-2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -60,8 +60,8 @@ component_static_lib += \
     libaudioparameters \
     libaudio_hal_utilities \
     libproperty \
-    libaudio_comms_utilities \
-    libaudio_comms_convert \
+    libaudio_utilities \
+    libaudio_utilities_convert \
     libhalaudiodump \
     liblpepreprocessinghelper
 
@@ -180,8 +180,8 @@ LOCAL_C_INCLUDES := \
 
 LOCAL_STATIC_LIBRARIES := \
         libaudioparameters \
-        libaudio_comms_utilities \
-        libaudio_comms_convert \
+        libaudio_utilities \
+        libaudio_utilities_convert \
         libmedia_helper \
         libutils
 

--- a/audio_stream_manager/src/CompressedStreamOut.cpp
+++ b/audio_stream_manager/src/CompressedStreamOut.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Intel Corporation
+ * Copyright (C) 2015-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,11 +41,11 @@
 
 using android::status_t;
 using namespace std;
-using audio_comms::utilities::convertTo;
-using audio_comms::utilities::Log;
-using audio_comms::utilities::Property;
-using audio_comms::utilities::Mutex;
-using audio_comms::utilities::ConditionVariable;
+using audio_utilities::utilities::convertTo;
+using audio_utilities::utilities::Log;
+using audio_utilities::utilities::Property;
+using audio_utilities::utilities::Mutex;
+using audio_utilities::utilities::ConditionVariable;
 
 namespace intel_audio
 {

--- a/audio_stream_manager/src/CompressedStreamOut.hpp
+++ b/audio_stream_manager/src/CompressedStreamOut.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Intel Corporation
+ * Copyright (C) 2015-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,15 +227,15 @@ private:
      */
     void recover();
 
-    audio_comms::utilities::ConditionVariable mCond;
+    audio_utilities::utilities::ConditionVariable mCond;
     SstState mState;
     compress *mCompress;
     float mVolume;
     bool mIsVolumeChangeRequestPending;
     size_t mBufferSize;
-    mutable audio_comms::utilities::Mutex mCodecLock;
+    mutable audio_utilities::utilities::Mutex mCodecLock;
     bool mIsNonBlocking;
-    audio_comms::utilities::ConditionVariable mOffloadCond;
+    audio_utilities::utilities::ConditionVariable mOffloadCond;
     pthread_t mOffloadThread;
     struct listnode mOffloadCmdList;
     bool mIsOffloadThreadBlocked;

--- a/audio_stream_manager/src/Device.cpp
+++ b/audio_stream_manager/src/Device.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,8 @@ static const audio_input_flags_t AUDIO_INPUT_FLAG_PRIMARY = static_cast<audio_in
 
 using namespace std;
 using android::status_t;
-using audio_comms::utilities::Log;
-using audio_comms::utilities::Mutex;
+using audio_utilities::utilities::Log;
+using audio_utilities::utilities::Mutex;
 
 namespace intel_audio
 {

--- a/audio_stream_manager/src/Device.hpp
+++ b/audio_stream_manager/src/Device.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ class AudioPlatformState;
 
 class Device : public DeviceInterface,
                public PatchInterface,
-               private audio_comms::utilities::NonCopyable
+               private audio_utilities::utilities::NonCopyable
 {
 private:
     typedef std::map<audio_io_handle_t, Stream *> StreamCollection;
@@ -391,7 +391,7 @@ private:
      * Protect concurrent access to routing control API to protect concurrent access to
      * patches collection.
      */
-    mutable audio_comms::utilities::Mutex mPatchCollectionLock;
+    mutable audio_utilities::utilities::Mutex mPatchCollectionLock;
 };
 
 } // namespace intel_audio

--- a/audio_stream_manager/src/Patch.cpp
+++ b/audio_stream_manager/src/Patch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Intel Corporation
+ * Copyright (C) 2015-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 #include <utils/Atomic.h>
 
 using android::status_t;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 using namespace std;
 
 namespace intel_audio

--- a/audio_stream_manager/src/Port.cpp
+++ b/audio_stream_manager/src/Port.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Intel Corporation
+ * Copyright (C) 2015-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 #include <utilities/Log.hpp>
 
 using android::status_t;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 using namespace std;
 
 namespace intel_audio

--- a/audio_stream_manager/src/Stream.cpp
+++ b/audio_stream_manager/src/Stream.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@
 #include <string>
 
 using android::status_t;
-using audio_comms::utilities::Log;
-using audio_comms::utilities::Property;
+using audio_utilities::utilities::Log;
+using audio_utilities::utilities::Property;
 using namespace std;
 
 namespace intel_audio

--- a/audio_stream_manager/src/Stream.hpp
+++ b/audio_stream_manager/src/Stream.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ class AudioConversion;
 class Stream
     : public virtual StreamInterface,
       public IoStream,
-      private audio_comms::utilities::NonCopyable
+      private audio_utilities::utilities::NonCopyable
 {
 public:
     virtual ~Stream();

--- a/audio_stream_manager/src/StreamIn.cpp
+++ b/audio_stream_manager/src/StreamIn.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,9 @@
 #include <algorithm>
 
 using namespace std;
-using audio_comms::utilities::BitField;
+using audio_utilities::utilities::BitField;
 using android::status_t;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 
 namespace intel_audio
 {

--- a/audio_stream_manager/src/StreamOut.cpp
+++ b/audio_stream_manager/src/StreamOut.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
 
 using namespace std;
 using android::status_t;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 
 namespace intel_audio
 {

--- a/audio_stream_manager/test/FunctionalTest.cpp
+++ b/audio_stream_manager/test/FunctionalTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 Intel Corporation
+ * Copyright (C) 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
 
 using namespace android;
 using namespace std;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 
 audio_module *AudioHalTest::mAudioModule = NULL;
 audio_hw_device_t *AudioHalTest::mDevice = NULL;

--- a/audio_stream_manager/test/FunctionalTestHost.cpp
+++ b/audio_stream_manager/test/FunctionalTestHost.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Intel Corporation
+ * Copyright (C) 2015-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
 
 using namespace android;
 using namespace std;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 
 intel_audio::Device *AudioHalTest::mDevice = NULL;
 

--- a/effects/pre-processing/Android.mk
+++ b/effects/pre-processing/Android.mk
@@ -1,6 +1,6 @@
 #
 #
-# Copyright (C) Intel 2013-2016
+# Copyright (C) Intel 2013-2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,8 +48,8 @@ effect_pre_proc_includes_dir_target := \
     $(foreach inc, $(effect_pre_proc_includes_dir), $(TARGET_OUT_HEADERS)/$(inc))
 
 effect_pre_proc_static_lib += \
-    libaudio_comms_utilities \
-    libaudio_comms_convert
+    libaudio_utilities \
+    libaudio_utilities_convert
 
 effect_pre_proc_static_lib_host += \
     $(foreach lib, $(effect_pre_proc_static_lib), $(lib)_host)
@@ -128,7 +128,7 @@ endif
 #######################################################################
 
 audio_effects_functional_test_static_lib += \
-    libaudio_comms_utilities \
+    libaudio_utilities \
 
 audio_effects_functional_test_src_files := \
     test/AudioEffectsFcct.cpp

--- a/effects/pre-processing/src/AudioEffect.cpp
+++ b/effects/pre-processing/src/AudioEffect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,8 @@ using android::AudioParameter;
 using android::String8;
 using android::AudioSystem;
 using android::NO_ERROR;
-using audio_comms::utilities::convertTo;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::convertTo;
+using audio_utilities::utilities::Log;
 
 const std::string AudioEffect::mParamKeyDelimiter = "-";
 

--- a/effects/pre-processing/src/AudioEffect.hpp
+++ b/effects/pre-processing/src/AudioEffect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 
 class AudioEffectSession;
 
-class AudioEffect : private audio_comms::utilities::NonCopyable
+class AudioEffect : private audio_utilities::utilities::NonCopyable
 {
 public:
     AudioEffect(const struct effect_interface_s *itfe, const effect_descriptor_t *descriptor);

--- a/effects/pre-processing/src/AudioEffectSession.cpp
+++ b/effects/pre-processing/src/AudioEffectSession.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@
 using android::status_t;
 using android::OK;
 using android::BAD_VALUE;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 
 AudioEffectSession::AudioEffectSession(uint32_t sessionId)
     : mId(sessionId)

--- a/effects/pre-processing/src/AudioEffectSession.hpp
+++ b/effects/pre-processing/src/AudioEffectSession.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
 
 class AudioEffect;
 
-class AudioEffectSession : private audio_comms::utilities::NonCopyable
+class AudioEffectSession : private audio_utilities::utilities::NonCopyable
 {
 private:
     typedef std::list<AudioEffect *>::iterator EffectListIterator;

--- a/effects/pre-processing/src/LpePreProcessing.cpp
+++ b/effects/pre-processing/src/LpePreProcessing.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,8 @@
 using android::status_t;
 using android::OK;
 using android::BAD_VALUE;
-using audio_comms::utilities::Mutex;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Mutex;
+using audio_utilities::utilities::Log;
 
 const struct effect_interface_s LpePreProcessing::mEffectInterface = {
     NULL, /**< process. Not implemented as this lib deals with HW effects. */

--- a/effects/pre-processing/src/LpePreProcessing.hpp
+++ b/effects/pre-processing/src/LpePreProcessing.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
 class AudioEffect;
 class AudioEffectSession;
 
-class LpePreProcessing : private audio_comms::utilities::NonCopyable
+class LpePreProcessing : private audio_utilities::utilities::NonCopyable
 {
 private:
     typedef std::list<AudioEffect *>::iterator EffectListIterator;
@@ -198,5 +198,5 @@ private:
      * Effects are handled in a separated thread, need to lock to protect concurrent
      * access to the input stream.
      */
-    audio_comms::utilities::Mutex mLpeEffectsLock;
+    audio_utilities::utilities::Mutex mLpeEffectsLock;
 };

--- a/effects/pre-processing/test/AudioEffectsFcct.cpp
+++ b/effects/pre-processing/test/AudioEffectsFcct.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 Intel Corporation
+ * Copyright (C) 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ using ::testing::Test;
 using std::string;
 using std::numeric_limits;
 using namespace android;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 
 const string AudioEffectsFunctionalTest::mLpeEffectLibPath =
     "/system/lib/soundfx/liblpepreprocessing.so";

--- a/effects/pre-processing/test/AudioEffectsFcct.hpp
+++ b/effects/pre-processing/test/AudioEffectsFcct.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016 Intel Corporation
+ * Copyright (C) 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@
 #include <string>
 #include <vector>
 
-class TestEffectParameterBase : private audio_comms::utilities::NonCopyable
+class TestEffectParameterBase : private audio_utilities::utilities::NonCopyable
 {
 public:
     enum Direction
@@ -58,7 +58,7 @@ public:
      * parametrized test suite.
      */
     TestEffectParameterBase(const TestEffectParameterBase &object)
-        : audio_comms::utilities::NonCopyable(),
+        : audio_utilities::utilities::NonCopyable(),
           mEffectUuidType(object.mEffectUuidType),
           mParam(NULL),
           mSize(object.mSize),
@@ -104,7 +104,7 @@ public:
         AUDIOUTILITIES_ASSERT(mParam != NULL, "Could not allocate effect param object");
         memcpy(mParam, param, mSize);
 
-        audio_comms::utilities::Log::Verbose() << __FUNCTION__
+        audio_utilities::utilities::Log::Verbose() << __FUNCTION__
                                                << ": param=" << *(uint32_t *)mParam->data
                                                << " val=" << *((uint16_t *)mParam->data + 2)
                                                << " paramSize=" << mParam->psize
@@ -114,7 +114,7 @@ public:
             sizeof(mParam->vsize);
 
         for (size_t i = 0; i < mSize / 2; i++) {
-            audio_comms::utilities::Log::Verbose() << "setEffectParam: dump param struct = effect["
+            audio_utilities::utilities::Log::Verbose() << "setEffectParam: dump param struct = effect["
                                                    << i
                                                    << "=" << *((uint16_t *)mParam + i)
                                                    << " @=" << (mParam + i);

--- a/hardware_device/Android.mk
+++ b/hardware_device/Android.mk
@@ -1,6 +1,6 @@
 #
 #
-# Copyright (C) Intel 2014-2016
+# Copyright (C) Intel 2014-2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
 LOCAL_SRC_FILES := \
     src/StreamWrapper.cpp
 LOCAL_CFLAGS := -Wall -Werror -Wextra
-LOCAL_STATIC_LIBRARIES := libaudio_comms_utilities
+LOCAL_STATIC_LIBRARIES := libaudio_utilities
 
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/include
 LOCAL_MODULE_TAGS := optional
@@ -47,7 +47,7 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
 LOCAL_SRC_FILES := \
     src/StreamWrapper.cpp
 LOCAL_CFLAGS := -Wall -Werror -Wextra -O0 -ggdb
-LOCAL_STATIC_LIBRARIES := libaudio_comms_utilities_host
+LOCAL_STATIC_LIBRARIES := libaudio_utilities_host
 
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/include
 LOCAL_MODULE_TAGS := optional
@@ -69,7 +69,7 @@ LOCAL_SRC_FILES := \
     test/DeviceWrapperTest.cpp \
     test/StreamWrapperTest.cpp
 
-LOCAL_STATIC_LIBRARIES := libaudio_comms_utilities_host
+LOCAL_STATIC_LIBRARIES := libaudio_utilities_host
 
 LOCAL_STATIC_LIBRARIES += \
     libaudiohw_intel_host \

--- a/hardware_device/include/DeviceWrapper.hpp
+++ b/hardware_device/include/DeviceWrapper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016 Intel Corporation
+ * Copyright (C) 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ namespace intel_audio
 {
 
 template <class Device, int CDeviceApiVersion>
-class DeviceWrapper : private audio_comms::utilities::NonCopyable
+class DeviceWrapper : private audio_utilities::utilities::NonCopyable
 {
 public:
     static int open(const hw_module_t *module, const char *name, hw_device_t **device);

--- a/hardware_device/include/StreamWrapper.hpp
+++ b/hardware_device/include/StreamWrapper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016 Intel Corporation
+ * Copyright (C) 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ struct InStreamTrait
 
 /** Common part of stream wrapper */
 template <class Trait>
-class StreamWrapper : private audio_comms::utilities::NonCopyable
+class StreamWrapper : private audio_utilities::utilities::NonCopyable
 {
 public:
     static typename Trait::CStream *bind(typename Trait::CppStream *cppStream)

--- a/parameter_mgr_helper/Android.mk
+++ b/parameter_mgr_helper/Android.mk
@@ -1,6 +1,6 @@
 #
 #
-# Copyright (C) Intel 2013-2016
+# Copyright (C) Intel 2013-2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,8 +48,8 @@ component_includes_dir_target := \
     $(component_common_includes_dir)
 
 component_static_lib := \
-    libaudio_comms_utilities \
-    libaudio_comms_convert \
+    libaudio_utilities \
+    libaudio_utilities_convert \
     libpfw_utility
 
 component_static_lib_host := \

--- a/parameter_mgr_helper/Criterion.cpp
+++ b/parameter_mgr_helper/Criterion.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 #include <utilities/Log.hpp>
 
 using std::string;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 
 Criterion::Criterion(const string &name,
                      CriterionType *criterionType,

--- a/parameter_mgr_helper/CriterionType.cpp
+++ b/parameter_mgr_helper/CriterionType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 #include <utilities/Log.hpp>
 
 using std::string;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 
 CriterionType::CriterionType(const string &name,
                              bool isInclusive,
@@ -70,12 +70,12 @@ bool CriterionType::getNumericalFromLiteral(const std::string &literalValue, int
         bool isValueProvidedAsHexa = !literalValue.compare(0, 2, "0x");
         if (isValueProvidedAsHexa) {
             uint32_t numericalUValue = 0;
-            if (!audio_comms::utilities::convertTo(value, numericalUValue)) {
+            if (!audio_utilities::utilities::convertTo(value, numericalUValue)) {
                 return false;
             }
             numerical = numericalUValue;
         } else {
-            if (!audio_comms::utilities::convertTo(value, numericalValue)) {
+            if (!audio_utilities::utilities::convertTo(value, numericalValue)) {
                 return false;
             }
             numerical = numericalValue;

--- a/parameter_mgr_helper/ParameterMgrHelper.cpp
+++ b/parameter_mgr_helper/ParameterMgrHelper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 #include <utilities/Log.hpp>
 #include <string>
 
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 using std::map;
 using std::string;
 using std::vector;

--- a/parameter_mgr_helper/includes/CriterionType.hpp
+++ b/parameter_mgr_helper/includes/CriterionType.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 class CParameterMgrPlatformConnector;
 class ISelectionCriterionTypeInterface;
 
-class CriterionType : public audio_comms::utilities::NonCopyable
+class CriterionType : public audio_utilities::utilities::NonCopyable
 {
 public:
     typedef std::pair<int, const char *> ValuePair;

--- a/sample_specifications/Android.mk
+++ b/sample_specifications/Android.mk
@@ -1,6 +1,6 @@
 #
 #
-# Copyright (C) Intel 2013-2016
+# Copyright (C) Intel 2013-2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,8 +43,8 @@ component_includes_dir_target := \
     $(call include-path-for, bionic)
 
 component_static_lib += \
-    libaudio_comms_convert \
-    libaudio_comms_utilities
+    libaudio_utilities_convert \
+    libaudio_utilities
 
 component_static_lib_host += \
     $(foreach lib, $(component_static_lib), $(lib)_host)

--- a/sample_specifications/src/AudioUtils.cpp
+++ b/sample_specifications/src/AudioUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,8 @@
 #include <utilities/Log.hpp>
 
 using namespace std;
-using audio_comms::utilities::convertTo;
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::convertTo;
+using audio_utilities::utilities::Log;
 
 namespace intel_audio
 {

--- a/sample_specifications/src/SampleSpec.cpp
+++ b/sample_specifications/src/SampleSpec.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 #include <errno.h>
 #include <limits>
 
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 using namespace std;
 
 namespace intel_audio

--- a/stream_lib/Android.mk
+++ b/stream_lib/Android.mk
@@ -1,6 +1,6 @@
 #
 #
-# Copyright (C) Intel 2013-2016
+# Copyright (C) Intel 2013-2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ component_includes_dir_target := \
 
 component_static_lib += \
     libsamplespec_static \
-    libaudio_comms_utilities \
+    libaudio_utilities \
     audio.routemanager.includes \
     libproperty
 

--- a/stream_lib/IoStream.cpp
+++ b/stream_lib/IoStream.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 #include <utils/RWLock.h>
 #include <utilities/Log.hpp>
 
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 using std::string;
 
 namespace intel_audio

--- a/stream_lib/TinyAlsaAudioDevice.cpp
+++ b/stream_lib/TinyAlsaAudioDevice.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 #include <AudioUtilitiesAssert.hpp>
 #include <utilities/Log.hpp>
 
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 using namespace std;
 
 namespace intel_audio

--- a/stream_lib/TinyAlsaIoStream.cpp
+++ b/stream_lib/TinyAlsaIoStream.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Intel Corporation
+ * Copyright (C) 2013-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 #include <AudioUtilitiesAssert.hpp>
 #include <utilities/Log.hpp>
 
-using audio_comms::utilities::Log;
+using audio_utilities::utilities::Log;
 using std::string;
 using android::status_t;
 using android::OK;

--- a/utilities/parameter/Android.mk
+++ b/utilities/parameter/Android.mk
@@ -1,6 +1,6 @@
 #
 #
-# Copyright (C) Intel 2014-2016
+# Copyright (C) Intel 2014-2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,8 +31,8 @@ component_src_files :=  \
 
 component_static_lib := \
     libaudio_hal_utilities \
-    libaudio_comms_utilities \
-    libaudio_comms_convert \
+    libaudio_utilities \
+    libaudio_utilities_convert \
 
 component_static_lib_host := \
     $(foreach lib, $(component_static_lib), $(lib)_host) \
@@ -91,8 +91,8 @@ LOCAL_C_INCLUDES := \
 
 LOCAL_STATIC_LIBRARIES += \
     libaudioparameters_host \
-    libaudio_comms_utilities_host \
-    libaudio_comms_convert_host
+    libaudio_utilities_host \
+    libaudio_utilities_convert_host
 
 LOCAL_CFLAGS := -Wall -Werror -Wextra
 

--- a/utilities/parameter/include/KeyValuePairs.hpp
+++ b/utilities/parameter/include/KeyValuePairs.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 Intel Corporation
+ * Copyright (C) 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ public:
     android::status_t add(const std::string &key, const T &value)
     {
         std::string literal;
-        if (!audio_comms::utilities::convertTo(value, literal)) {
+        if (!audio_utilities::utilities::convertTo(value, literal)) {
             return android::BAD_VALUE;
         }
         return addLiteral(key, literal);
@@ -114,7 +114,7 @@ public:
         if (status != android::OK) {
             return status;
         }
-        if (!audio_comms::utilities::convertTo(literalValue, value)) {
+        if (!audio_utilities::utilities::convertTo(literalValue, value)) {
             return android::BAD_VALUE;
         }
         return android::OK;

--- a/utilities/parameter/src/KeyValuePairs.cpp
+++ b/utilities/parameter/src/KeyValuePairs.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 Intel Corporation
+ * Copyright (C) 2014-2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-using namespace audio_comms::utilities;
+using namespace audio_utilities::utilities;
 using namespace std;
 
 namespace intel_audio


### PR DESCRIPTION
@plbossart @cc6565 please review as per final renaming align with internal tree.
Link to https://github.com/android-ia/hardware_intel_audiocomms_utilities/pull/2

In order to remove legacy audio_comms branding the namespace is
remane to audio_utilities.

Jira: None

Test: build and run under Intel Nuc.

Signed-off-by: Sebastien Guiriec <sebastien.guiriec@intel.com>